### PR TITLE
Move Helios runner to Run and Debug view

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Features:
  * Syntax highlighting for .hl files.
  * Syntax error diagnostics
+ * Helios Runner available in the Run and Debug view
 
 ## Further reading
 https://macromates.com/manual/en/language_grammars#naming-conventions
@@ -12,3 +13,6 @@ https://macromates.com/manual/en/language_grammars#naming-conventions
 To see the token scope names in VSCode, open the command palette (ctrl+shift+p), and search for 'Developer: Inspect Editor Tokens And Scope'
 
 Hot reload plugins: in command palette search for 'Reload window'
+
+The Helios Runner can be found in the **Run and Debug** sidebar. Open a Helios
+file to automatically reveal the widget.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
             }
         ],
         "views": {
-            "explorer": [
+            "debug": [
                 {
                     "id": "helios.runView",
                     "name": "Helios Runner"


### PR DESCRIPTION
## Summary
- expose Helios runner inside the Run and Debug sidebar
- document that the runner is found in the Run and Debug view

## Testing
- `pnpm install`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bd7a61bfc8330a014d6f2a87b8f3f