### PR TITLE
Add dropdown for selecting Helios validator file

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "views": {
             "debug": [
                 {
+                    "type": "webview",
                     "id": "helios.runView",
                     "name": "Helios Runner"
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import {
         ExtensionContext,
         window,
-        commands
+        commands,
+        workspace,
+        TextDocument
 } from "vscode"
 
 import {
@@ -24,6 +26,13 @@ export function activate(context: ExtensionContext) {
         const cache = new Cache()
         const runViewProvider = new RunViewProvider(context, cache)
 
+        const updateFiles = () => {
+                const files = workspace.textDocuments
+                        .filter(doc => isHeliosExt(doc.fileName))
+                        .map(doc => doc.fileName)
+                runViewProvider.setFileList(files)
+        }
+
 	/*languages.registerDocumentFormattingEditProvider('helios', {
 		provideDocumentFormattingEdits: (document) => {
 			const firstLine = document.lineAt(0);
@@ -40,6 +49,8 @@ export function activate(context: ExtensionContext) {
         context.subscriptions.push(
                 window.registerWebviewViewProvider(RunViewProvider.viewType, runViewProvider)
         )
+
+        updateFiles()
 
         context.subscriptions.push(
                 commands.registerCommand("helios.showRunView", () => runViewProvider.reveal())
@@ -60,6 +71,23 @@ export function activate(context: ExtensionContext) {
                                         }
                                 }
                                 runViewProvider.reveal()
+                        }
+                        updateFiles()
+                })
+        )
+
+        context.subscriptions.push(
+                workspace.onDidOpenTextDocument(doc => {
+                        if (isHeliosExt(doc.fileName)) {
+                                updateFiles()
+                        }
+                })
+        )
+
+        context.subscriptions.push(
+                workspace.onDidCloseTextDocument(doc => {
+                        if (isHeliosExt(doc.fileName)) {
+                                updateFiles()
                         }
                 })
         )

--- a/src/runView.ts
+++ b/src/runView.ts
@@ -6,10 +6,13 @@ import {
     CancellationToken,
     commands,
     window,
-    debug
+    debug,
+    workspace,
+    TextDocument
 } from "vscode"
 
 import { createRequire } from "module"
+import * as path from "path"
 
 import { Cache } from "./cache"
 import { isHeliosExt } from "./repository"
@@ -37,7 +40,7 @@ export class RunViewProvider implements WebviewViewProvider {
         webviewView.webview.html = this.html()
         webviewView.webview.onDidReceiveMessage(async msg => {
             if (msg.command == "run") {
-                await this.run(msg.validator, msg.input)
+                await this.run(msg.file, msg.input)
             }
         })
     }
@@ -56,6 +59,13 @@ export class RunViewProvider implements WebviewViewProvider {
         }
     }
 
+    setFileList(files: string[]) {
+        if (this.#view) {
+            const mapped = files.map(f => ({ path: f, name: path.basename(f) }))
+            this.#view.webview.postMessage({ command: "setFiles", files: mapped })
+        }
+    }
+
     private html(): string {
         const nonce = Date.now().toString()
         return `<!DOCTYPE html>
@@ -66,6 +76,8 @@ export class RunViewProvider implements WebviewViewProvider {
     textarea { width: 100%; height: 60px; }
     input { width: 100%; }
     </style>
+    <label>Validator file:</label><br/>
+    <select id="file"></select><br/>
     <label>Validator name:</label><br/>
     <input id="validator" /><br/>
     <label>Input (JSON or hex CBOR):</label><br/>
@@ -76,6 +88,7 @@ export class RunViewProvider implements WebviewViewProvider {
     document.getElementById('run').addEventListener('click', () => {
         vscode.postMessage({
             command: 'run',
+            file: document.getElementById('file').value,
             validator: document.getElementById('validator').value,
             input: document.getElementById('input').value
         });
@@ -85,20 +98,40 @@ export class RunViewProvider implements WebviewViewProvider {
         if (m.command === 'setValidator') {
             document.getElementById('validator').value = m.validator;
         }
+        if (m.command === 'setFiles') {
+            const sel = document.getElementById('file');
+            while (sel.firstChild) sel.removeChild(sel.firstChild);
+            m.files.forEach((f) => {
+                const opt = document.createElement('option');
+                opt.value = f.path;
+                opt.textContent = f.name;
+                sel.appendChild(opt);
+            });
+        }
     });
     </script>
 </body>
 </html>`
     }
 
-    private async run(_validator: string, input: string) {
-        const editor = window.activeTextEditor
-        if (!editor) {
+    private async run(file: string, input: string) {
+        let doc: TextDocument | undefined
+        const open = workspace.textDocuments.find(d => d.fileName === file)
+        if (open) {
+            doc = open
+        } else {
+            try {
+                doc = await workspace.openTextDocument(file)
+            } catch {
+                const editor = window.activeTextEditor
+                doc = editor?.document
+            }
+        }
+        if (!doc) {
             return
         }
-        const doc = editor.document
         if (!isHeliosExt(doc.fileName)) {
-            debug.activeDebugConsole.appendLine("Active file is not a Helios script")
+            debug.activeDebugConsole.appendLine("Selected file is not a Helios script")
             return
         }
 


### PR DESCRIPTION
## Summary
- add a webview type declaration so the Helios Runner is shown
- show only the filename in the validator dropdown

## Testing
- `pnpm install` *(failed to install VS Code due to missing `code` command, but build succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd3840ac8330a828e7d9406c8416